### PR TITLE
Add tests for optional attendees

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -359,7 +359,7 @@ public final class FindMeetingQueryTest {
     request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList();
+    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
 
     Assert.assertEquals(expected, actual);
   }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -274,7 +274,7 @@ public final class FindMeetingQueryTest {
   }
 
   @Test
-  public void optionalWholeDay() {
+  public void mandatoryGapsOptionalWholeDayWithOpenings() {
     // Have each mandatory person have different events, as well as one optional attendee with 
     // an all-day event.
     //
@@ -305,7 +305,7 @@ public final class FindMeetingQueryTest {
   }
 
   @Test
-  public void withOptionalEvent() {
+  public void mandatoryGapsOptionalGapsWithOpenings() {
     // Have each mandatory person have different events, as well as one optional attendee with 
     // an event that conflicts with an open slot.
     // This optional attendee's event should block the middle of the day, and only produce
@@ -337,7 +337,7 @@ public final class FindMeetingQueryTest {
   }
 
   @Test
-  public void optionalIgnored() {
+  public void mandatoryGapsOptionalIgnoredWithOpenings() {
     // Have one person, but make it so that there is just enough room at one point in the day to
     // have the meeting. The optional attendee should be ignored because their schedule blocks 
     // out the only available time.
@@ -345,7 +345,7 @@ public final class FindMeetingQueryTest {
     // Events  : |--A--|     |----A----|
     // Optional:       |B|
     // Day     : |---------------------|
-    // Options :
+    // Options :       |--1--|
 
     Collection<Event> events = Arrays.asList(
         new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
@@ -365,7 +365,7 @@ public final class FindMeetingQueryTest {
   }
 
   @Test
-  public void optionalOnly() {
+  public void optionalGapsWithOpenings() {
     // Have no mandatory employees, but have several optional employees that can be accommodated.
     //
     // Optional: |--A--|     |--B--|
@@ -391,7 +391,7 @@ public final class FindMeetingQueryTest {
   }
 
   @Test
-  public void optionalOnlyNoGaps() {
+  public void optionalNoGapsNoOpenings() {
     // Have no mandatory employees, but have several optional employees with no mutual 
     // availabilities. No schedulable time should be found.
     //

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -402,7 +402,7 @@ public final class FindMeetingQueryTest {
     Collection<Event> events = Arrays.asList(
         new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false), 
             Arrays.asList(PERSON_A)), 
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true), 
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0830AM, TimeRange.END_OF_DAY, true), 
             Arrays.asList(PERSON_B)));
     
     MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,10 +34,12 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
   private static final int TIME_0830AM = TimeRange.getTimeInMinutes(8, 30);
+  private static final int TIME_0845AM = TimeRange.getTimeInMinutes(8, 45);
   private static final int TIME_0900AM = TimeRange.getTimeInMinutes(9, 0);
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
@@ -270,5 +272,146 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
-}
 
+  @Test
+  public void optionalWholeDay() {
+    // Have each mandatory person have different events, as well as one optional attendee with 
+    // an all-day event.
+    //
+    // Events  :       |--A--|     |--B--|
+    // Optional: |--------------C--------------|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)), 
+        new Event("Event 3", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, 
+            TimeRange.END_OF_DAY), Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void withOptionalEvent() {
+    // Have each mandatory person have different events, as well as one optional attendee with 
+    // an event that conflicts with an open slot.
+    // This optional attendee's event should block the middle of the day, and only produce
+    // the beginning and end of the day as options.
+    //
+    // Events  :       |--A--|     |--B--|
+    // Optional:             |--C--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|                 |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)), 
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, TIME_0900AM), 
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalIgnored() {
+    // Have one person, but make it so that there is just enough room at one point in the day to
+    // have the meeting. The optional attendee should be ignored because their schedule blocks 
+    // out the only available time.
+    //
+    // Events  : |--A--|     |----A----|
+    // Optional:       |B|
+    // Day     : |---------------------|
+    // Options :
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, true),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalOnly() {
+    // Have no mandatory employees, but have several optional employees that can be accommodated.
+    //
+    // Optional: |--A--|     |--B--|
+    // Day     : |---------------------|
+    // Options :       |--1--|     |-2-|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false), 
+            Arrays.asList(PERSON_A)), 
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES), 
+            Arrays.asList(PERSON_B)));
+    
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = 
+        Arrays.asList(TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false), 
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalOnlyNoGaps() {
+    // Have no mandatory employees, but have several optional employees with no mutual 
+    // availabilities. No schedulable time should be found.
+    //
+    // Optional: |----A----||----B-----|
+    // Day     : |---------------------|
+    // Options :
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false), 
+            Arrays.asList(PERSON_A)), 
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true), 
+            Arrays.asList(PERSON_B)));
+    
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+}


### PR DESCRIPTION
This PR has 5 new tests that satisfy these requirements:

- Based on `everyAttendeeIsConsidered`, add an optional attendee C who has an all-day event. The same three time slots should be returned as when C was not invited.

- Also based on `everyAttendeeIsConsidered`, add an optional attendee C who has an event between 8:30 and 9:00. Now only the early and late parts of the day should be returned.

- Based on `justEnoughRoom`, add an optional attendee B who has an event between 8:30 and 8:45. The optional attendee should be ignored since considering their schedule would result in a time slot smaller than the requested time.

- No mandatory attendees, just two optional attendees with several gaps in their schedules. Those gaps should be identified and returned.

- No mandatory attendees, just two optional attendees with no gaps in their schedules. query should return that no time is available.